### PR TITLE
Update vercel-merge.yml

### DIFF
--- a/.github/workflows/vercel-merge.yml
+++ b/.github/workflows/vercel-merge.yml
@@ -17,7 +17,4 @@ jobs:
           vercel-args: "--prod"
           vercel-org-id: ${{ secrets.ORG_ID}}
           vercel-project-id: ${{ secrets.PROJECT_ID}}
-<<<<<<< HEAD
-=======
           scope: ${{ secrets.ORG_ID }}
->>>>>>> 11a55becfcb4275dcc1f51026a0beea3f08eb7a6


### PR DESCRIPTION
Fixes .yaml-type syntax to re-enable redeployment of `master` branch to Vercel production.